### PR TITLE
Return active variant in hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,5 +103,15 @@ The main container component. Requires the `<Variant />` as a child.
     	    - Example - `{ A: <div>Variant A</div>, B: <div>Variant B</div> }`
     	    - *Required*
 
-
+- Returns:
+    - Type - Object
+    - Props:
+        -  `Variant`
+            - Type - React.Element
+        - `experimentName`
+            - Type - String
+        - `activeVariant`
+            - Type - String
+        - `experimentLoaded` 
+            - Type - Boolean
 

--- a/src/experiment.js
+++ b/src/experiment.js
@@ -88,8 +88,8 @@ function useExperiment({
 		// eslint-disable-next-line react/display-name
 		Variant: () => <>{variants[definedActiveVariant]}</>,
 		experimentName: name,
-		variantName: definedActiveVariant,
-		experimentLoaded: Boolean(definedActiveVariant)
+		activeVariant: definedActiveVariant,
+		experimentLoaded: Boolean(definedActiveVariant),
 	};
 }
 

--- a/tests/experiment.test.js
+++ b/tests/experiment.test.js
@@ -146,9 +146,9 @@ describe("useExperiment hook", () => {
 		expect(component.contains(<div>Ash</div>) || component.contains(<div>Gary</div>)).toBe(true);
 	});
 
-	it("should render the variant name", () => {
+	it("should render the variant name (which is the active variant)", () => {
 		const NameTag = () => {
-			const { variantName } = useExperiment({
+			const { activeVariant } = useExperiment({
 				name: "Experiment-test",
 				variants: {
 					A: <div>Ash</div>,
@@ -158,7 +158,7 @@ describe("useExperiment hook", () => {
 
 			return (
 				<div>
-					{variantName}
+					{activeVariant}
 				</div>
 			)
 		};


### PR DESCRIPTION
- Changed `variantName` to `activeVariant` so it makes more sense.
- Changed one of the tests to accompany this change.
- Added more docs regarding returned values in hook